### PR TITLE
[Debug] Credit Purchase Flow

### DIFF
--- a/src/components/DebugLayout.tsx
+++ b/src/components/DebugLayout.tsx
@@ -2,31 +2,49 @@ import React, { ReactNode, useState, useEffect } from 'react';
 import { DebugPanel, JsonViewer } from './DebugPanel';
 import { DebugLog } from './DebugLog';
 import { debugLog } from '../stores/debug';
+import { useWalletStore } from '../stores/wallet';
+import { PurchasePanel } from './PurchasePanel';
 
 interface DebugLayoutProps {
   trackList: ReactNode;
 }
 
-// Placeholder wallet panel - will be connected to real store later
+// Wallet panel connected to real store
 function WalletPanel() {
-  const [balance] = useState(0);
-  const [proofs] = useState<unknown[]>([]);
+  const proofs = useWalletStore(state => state.proofs);
+  const pendingProofs = useWalletStore(state => state.pendingProofs);
+  const balance = useWalletStore(state => state.getBalance());
+  const reset = useWalletStore(state => state.reset);
 
   return (
     <DebugPanel title="Wallet State">
       <div className="space-y-3">
         <div className="flex justify-between items-center">
           <span className="text-xs text-gray-400">Balance</span>
-          <span className="text-sm font-mono text-white">{balance} credits</span>
+          <span className="text-sm font-mono text-green-400">{balance} credits</span>
         </div>
         <div>
           <span className="text-xs text-gray-400 block mb-1">Proofs ({proofs.length})</span>
           {proofs.length > 0 ? (
-            <JsonViewer data={proofs} maxHeight="100px" />
+            <JsonViewer data={proofs.map(p => ({ amount: p.amount, id: p.id?.slice(0, 8) }))} maxHeight="100px" />
           ) : (
             <span className="text-xs text-gray-500">No proofs loaded</span>
           )}
         </div>
+        {pendingProofs.length > 0 && (
+          <div>
+            <span className="text-xs text-yellow-400 block mb-1">Pending ({pendingProofs.length})</span>
+            <JsonViewer data={pendingProofs.map(p => ({ amount: p.amount }))} maxHeight="60px" />
+          </div>
+        )}
+        {proofs.length > 0 && (
+          <button
+            onClick={reset}
+            className="w-full py-1 text-xs text-gray-400 hover:text-red-400 transition-colors"
+          >
+            🗑 Clear Wallet
+          </button>
+        )}
       </div>
     </DebugPanel>
   );
@@ -182,6 +200,7 @@ export default function DebugLayout({ trackList }: DebugLayoutProps) {
         <aside className="w-80 flex-none border-l border-surface-light overflow-auto bg-surface/30">
           <div className="p-3 space-y-3">
             <h2 className="text-sm font-medium text-white">Debug Panels</h2>
+            <PurchasePanel />
             <WalletPanel />
             <ApiConfigPanel />
           </div>

--- a/src/components/PurchasePanel.tsx
+++ b/src/components/PurchasePanel.tsx
@@ -1,0 +1,180 @@
+import { useState } from 'react';
+import { DebugPanel } from './DebugPanel';
+import { usePurchaseStore } from '../stores/purchase';
+import { useWalletStore } from '../stores/wallet';
+
+export function PurchasePanel() {
+  const [amount, setAmount] = useState(100);
+  const [copied, setCopied] = useState(false);
+  
+  const {
+    quoteId,
+    bolt11,
+    quoteAmount,
+    quoteExpiry,
+    quotePaid,
+    mintedProofs,
+    isCreatingQuote,
+    isCheckingStatus,
+    isMinting,
+    error,
+    createQuote,
+    checkQuoteStatus,
+    mintTokens,
+    reset,
+  } = usePurchaseStore();
+  
+  const balance = useWalletStore(state => state.getBalance());
+  
+  const handleCreateQuote = async () => {
+    await createQuote(amount);
+  };
+  
+  const handleCheckStatus = async () => {
+    await checkQuoteStatus();
+  };
+  
+  const handleMint = async () => {
+    await mintTokens();
+  };
+  
+  const handleCopyInvoice = async () => {
+    if (bolt11) {
+      await navigator.clipboard.writeText(bolt11);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+  
+  const isExpired = quoteExpiry && new Date() > quoteExpiry;
+  
+  return (
+    <DebugPanel title="Buy Credits">
+      <div className="space-y-4">
+        {/* Wallet Balance */}
+        <div className="flex justify-between items-center p-2 bg-surface-light rounded">
+          <span className="text-xs text-gray-400">Wallet Balance</span>
+          <span className="text-sm font-mono text-green-400">{balance} credits</span>
+        </div>
+        
+        {/* Amount Input */}
+        {!quoteId && (
+          <div className="space-y-2">
+            <label className="text-xs text-gray-400 block">Amount (credits)</label>
+            <div className="flex gap-2">
+              <input
+                type="number"
+                value={amount}
+                onChange={(e) => setAmount(Math.max(1, parseInt(e.target.value) || 0))}
+                className="flex-1 px-3 py-2 text-sm font-mono bg-background border border-surface-light rounded text-white focus:outline-none focus:border-primary"
+                min={1}
+                disabled={isCreatingQuote}
+              />
+              <button
+                onClick={handleCreateQuote}
+                disabled={isCreatingQuote || amount < 1}
+                className="px-4 py-2 text-sm font-medium bg-primary hover:bg-primary-600 text-white rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isCreatingQuote ? 'Creating...' : 'Create Quote'}
+              </button>
+            </div>
+          </div>
+        )}
+        
+        {/* Quote Info */}
+        {quoteId && (
+          <div className="space-y-3">
+            <div className="p-2 bg-surface-light rounded space-y-1">
+              <div className="flex justify-between text-xs">
+                <span className="text-gray-400">Quote ID</span>
+                <span className="font-mono text-gray-300">{quoteId.slice(0, 12)}...</span>
+              </div>
+              <div className="flex justify-between text-xs">
+                <span className="text-gray-400">Amount</span>
+                <span className="font-mono text-white">{quoteAmount} credits</span>
+              </div>
+              <div className="flex justify-between text-xs">
+                <span className="text-gray-400">Status</span>
+                <span className={`font-medium ${
+                  quotePaid ? 'text-green-400' : isExpired ? 'text-red-400' : 'text-yellow-400'
+                }`}>
+                  {quotePaid ? '✅ PAID' : isExpired ? '❌ Expired' : '⏳ Unpaid'}
+                </span>
+              </div>
+            </div>
+            
+            {/* Invoice Display */}
+            {bolt11 && !quotePaid && !isExpired && (
+              <div className="space-y-2">
+                <label className="text-xs text-gray-400 block">Lightning Invoice</label>
+                <div className="p-2 bg-background border border-surface-light rounded">
+                  <code className="text-xs text-gray-300 break-all block max-h-20 overflow-auto">
+                    {bolt11}
+                  </code>
+                </div>
+                <button
+                  onClick={handleCopyInvoice}
+                  className="w-full py-2 text-xs font-medium bg-surface-light hover:bg-surface text-white rounded transition-colors"
+                >
+                  {copied ? '✓ Copied!' : '📋 Copy Invoice'}
+                </button>
+              </div>
+            )}
+            
+            {/* Check Status Button */}
+            {!quotePaid && !isExpired && (
+              <button
+                onClick={handleCheckStatus}
+                disabled={isCheckingStatus}
+                className="w-full py-2 text-sm font-medium bg-blue-600 hover:bg-blue-700 text-white rounded transition-colors disabled:opacity-50"
+              >
+                {isCheckingStatus ? 'Checking...' : '🔄 Check Status'}
+              </button>
+            )}
+            
+            {/* Mint Button */}
+            {quotePaid && !mintedProofs && (
+              <button
+                onClick={handleMint}
+                disabled={isMinting}
+                className="w-full py-2 text-sm font-medium bg-green-600 hover:bg-green-700 text-white rounded transition-colors disabled:opacity-50"
+              >
+                {isMinting ? 'Minting...' : '🪙 Mint Tokens'}
+              </button>
+            )}
+            
+            {/* Success Message */}
+            {mintedProofs && (
+              <div className="p-3 bg-green-900/30 border border-green-500/50 rounded">
+                <p className="text-sm text-green-400 font-medium mb-1">
+                  ✅ Minted Successfully!
+                </p>
+                <p className="text-xs text-green-300">
+                  {mintedProofs.length} proof{mintedProofs.length !== 1 ? 's' : ''} added to wallet
+                </p>
+                <p className="text-xs text-green-300 font-mono">
+                  Total: {mintedProofs.reduce((s, p) => s + p.amount, 0)} credits
+                </p>
+              </div>
+            )}
+            
+            {/* Reset Button */}
+            <button
+              onClick={reset}
+              className="w-full py-2 text-xs text-gray-400 hover:text-white transition-colors"
+            >
+              ↩ Start Over
+            </button>
+          </div>
+        )}
+        
+        {/* Error Display */}
+        {error && (
+          <div className="p-2 bg-red-900/30 border border-red-500/50 rounded">
+            <p className="text-xs text-red-400">{error}</p>
+          </div>
+        )}
+      </div>
+    </DebugPanel>
+  );
+}

--- a/src/lib/blinding.ts
+++ b/src/lib/blinding.ts
@@ -1,0 +1,152 @@
+/**
+ * Cashu blinding utilities
+ * 
+ * Uses cashu-ts to:
+ * 1. Create blinded outputs for minting
+ * 2. Unblind signatures to get proofs
+ * 3. Encode proofs as cashuB tokens
+ */
+
+import {
+  Mint,
+  Wallet,
+  OutputData,
+  getEncodedTokenV4,
+  type Proof,
+  type SerializedBlindedMessage,
+  type SerializedBlindedSignature,
+  type MintKeys,
+} from '@cashu/cashu-ts';
+import { CONFIG } from './config';
+import { debugLog } from '../stores/debug';
+
+// Cached mint and wallet instances
+let mintInstance: Mint | null = null;
+let walletInstance: Wallet | null = null;
+
+/**
+ * Get or create the Mint instance
+ */
+export async function getMint(): Promise<Mint> {
+  if (!mintInstance) {
+    debugLog('wallet', 'Initializing Mint', { url: CONFIG.MINT_URL });
+    mintInstance = new Mint(CONFIG.MINT_URL);
+  }
+  return mintInstance;
+}
+
+/**
+ * Get or create the Wallet instance
+ */
+export async function getWallet(): Promise<Wallet> {
+  if (!walletInstance) {
+    const mint = await getMint();
+    debugLog('wallet', 'Initializing Wallet');
+    walletInstance = new Wallet(mint, { unit: 'usd' });
+    
+    // Load mint info and keys
+    await walletInstance.loadMint();
+    debugLog('wallet', 'Mint loaded', { 
+      keysetId: walletInstance.keysetId 
+    });
+  }
+  return walletInstance;
+}
+
+/**
+ * Get the active keyset
+ */
+export async function getKeyset(): Promise<{ id: string; keys: MintKeys['keys'] }> {
+  const wallet = await getWallet();
+  const keyset = wallet.getKeyset();
+  return {
+    id: keyset.id,
+    keys: keyset.keys,
+  };
+}
+
+/**
+ * Create blinded outputs for a given amount
+ * Returns the blinded messages to send to mint + data needed to unblind
+ */
+export async function createBlindedOutputs(
+  amount: number
+): Promise<{
+  outputs: SerializedBlindedMessage[];
+  outputData: OutputData[];
+}> {
+  const wallet = await getWallet();
+  const keyset = wallet.getKeyset();
+  
+  debugLog('wallet', 'Creating blinded outputs', { amount, keysetId: keyset.id });
+  
+  // Create random blinded outputs using OutputData helper
+  const outputData = OutputData.createRandomData(amount, keyset);
+  
+  // Extract the serialized blinded messages
+  const outputs = outputData.map(d => d.blindedMessage);
+  
+  debugLog('wallet', 'Created blinded outputs', { 
+    count: outputs.length,
+    amounts: outputs.map(m => m.amount)
+  });
+  
+  return {
+    outputs,
+    outputData,
+  };
+}
+
+/**
+ * Unblind signatures to get proofs
+ */
+export async function unblindSignatures(
+  signatures: SerializedBlindedSignature[],
+  outputData: OutputData[]
+): Promise<Proof[]> {
+  const wallet = await getWallet();
+  const keyset = wallet.getKeyset();
+  
+  debugLog('wallet', 'Unblinding signatures', { count: signatures.length });
+  
+  // Convert each signature to a proof using the outputData
+  const proofs: Proof[] = signatures.map((sig, i) => {
+    return outputData[i].toProof(sig, keyset);
+  });
+  
+  debugLog('wallet', 'Unblinded to proofs', { 
+    count: proofs.length,
+    amounts: proofs.map(p => p.amount),
+    total: proofs.reduce((s, p) => s + p.amount, 0)
+  });
+  
+  return proofs;
+}
+
+/**
+ * Encode proofs as a cashuB (v4) token
+ */
+export function encodeToken(proofs: Proof[]): string {
+  debugLog('wallet', 'Encoding token', { proofCount: proofs.length });
+  
+  const token = getEncodedTokenV4({
+    mint: CONFIG.MINT_URL,
+    proofs,
+    unit: 'usd',
+  });
+  
+  debugLog('wallet', 'Token encoded', { 
+    tokenLength: token.length,
+    prefix: token.slice(0, 20) + '...'
+  });
+  
+  return token;
+}
+
+/**
+ * Get the current keyset ID
+ */
+export async function getKeysetId(): Promise<string> {
+  const wallet = await getWallet();
+  return wallet.keysetId;
+}

--- a/src/stores/purchase.ts
+++ b/src/stores/purchase.ts
@@ -1,0 +1,268 @@
+import { create } from 'zustand';
+import type { Proof, OutputData, SerializedBlindedMessage } from '@cashu/cashu-ts';
+import { CONFIG } from '../lib/config';
+import { debugLog } from './debug';
+import { useWalletStore } from './wallet';
+import { 
+  createBlindedOutputs, 
+  unblindSignatures,
+} from '../lib/blinding';
+
+interface QuoteResponse {
+  quoteId: string;
+  bolt11: string;
+  amount: number;
+  expiresAt: string;
+}
+
+interface QuoteStatusResponse {
+  quoteId: string;
+  paid: boolean;
+  amount: number;
+  expiresAt: string;
+}
+
+interface MintResponse {
+  signatures: Array<{
+    id: string;
+    amount: number;
+    C_: string;
+  }>;
+}
+
+interface PurchaseState {
+  // Quote state
+  quoteId: string | null;
+  bolt11: string | null;
+  quoteAmount: number;
+  quoteExpiry: Date | null;
+  quotePaid: boolean;
+  
+  // Minting state
+  blindedOutputs: SerializedBlindedMessage[] | null;
+  outputData: OutputData[] | null;
+  mintedProofs: Proof[] | null;
+  
+  // Loading states
+  isCreatingQuote: boolean;
+  isCheckingStatus: boolean;
+  isMinting: boolean;
+  
+  // Error state
+  error: string | null;
+  
+  // Actions
+  createQuote: (amount: number) => Promise<void>;
+  checkQuoteStatus: () => Promise<boolean>;
+  mintTokens: () => Promise<void>;
+  reset: () => void;
+}
+
+export const usePurchaseStore = create<PurchaseState>((set, get) => ({
+  // Initial state
+  quoteId: null,
+  bolt11: null,
+  quoteAmount: 0,
+  quoteExpiry: null,
+  quotePaid: false,
+  
+  blindedOutputs: null,
+  outputData: null,
+  mintedProofs: null,
+  
+  isCreatingQuote: false,
+  isCheckingStatus: false,
+  isMinting: false,
+  error: null,
+  
+  createQuote: async (amount: number) => {
+    set({ isCreatingQuote: true, error: null });
+    
+    const url = `${CONFIG.CONTENT_API_URL}/credits/quote`;
+    debugLog('request', `POST ${url}`, { amount });
+    
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ amount }),
+      });
+      
+      if (!response.ok) {
+        const errorText = await response.text();
+        debugLog('error', `Quote creation failed: ${response.status}`, { 
+          status: response.status, 
+          body: errorText 
+        });
+        throw new Error(`Failed to create quote: ${response.status} ${errorText}`);
+      }
+      
+      const data: QuoteResponse = await response.json();
+      debugLog('response', `POST ${url}`, data);
+      
+      set({
+        quoteId: data.quoteId,
+        bolt11: data.bolt11,
+        quoteAmount: data.amount,
+        quoteExpiry: new Date(data.expiresAt),
+        quotePaid: false,
+        isCreatingQuote: false,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      debugLog('error', 'Quote creation error', { error: message });
+      set({ 
+        isCreatingQuote: false, 
+        error: message 
+      });
+    }
+  },
+  
+  checkQuoteStatus: async () => {
+    const { quoteId } = get();
+    if (!quoteId) {
+      debugLog('error', 'No quote ID to check');
+      return false;
+    }
+    
+    set({ isCheckingStatus: true, error: null });
+    
+    const url = `${CONFIG.CONTENT_API_URL}/credits/quote/${quoteId}`;
+    debugLog('request', `GET ${url}`);
+    
+    try {
+      const response = await fetch(url);
+      
+      if (!response.ok) {
+        const errorText = await response.text();
+        debugLog('error', `Quote status check failed: ${response.status}`, { 
+          status: response.status, 
+          body: errorText 
+        });
+        throw new Error(`Failed to check quote: ${response.status}`);
+      }
+      
+      const data: QuoteStatusResponse = await response.json();
+      debugLog('response', `GET ${url}`, data);
+      
+      set({
+        quotePaid: data.paid,
+        isCheckingStatus: false,
+      });
+      
+      return data.paid;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      debugLog('error', 'Quote status check error', { error: message });
+      set({ 
+        isCheckingStatus: false, 
+        error: message 
+      });
+      return false;
+    }
+  },
+  
+  mintTokens: async () => {
+    const { quoteId, quoteAmount, quotePaid } = get();
+    
+    if (!quoteId) {
+      debugLog('error', 'No quote ID for minting');
+      set({ error: 'No quote ID' });
+      return;
+    }
+    
+    if (!quotePaid) {
+      debugLog('error', 'Quote not paid yet');
+      set({ error: 'Quote not paid' });
+      return;
+    }
+    
+    set({ isMinting: true, error: null });
+    
+    try {
+      // Step 1: Create blinded outputs
+      debugLog('wallet', 'Starting mint process', { quoteId, amount: quoteAmount });
+      const { outputs, outputData } = await createBlindedOutputs(quoteAmount);
+      
+      set({ blindedOutputs: outputs, outputData });
+      
+      // Step 2: Send to mint endpoint
+      const url = `${CONFIG.CONTENT_API_URL}/credits/mint/bolt11`;
+      const body = {
+        quote: quoteId,
+        outputs: outputs,
+      };
+      
+      debugLog('request', `POST ${url}`, body);
+      
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+      
+      if (!response.ok) {
+        const errorText = await response.text();
+        debugLog('error', `Mint failed: ${response.status}`, { 
+          status: response.status, 
+          body: errorText 
+        });
+        throw new Error(`Failed to mint: ${response.status} ${errorText}`);
+      }
+      
+      const data: MintResponse = await response.json();
+      debugLog('response', `POST ${url}`, data);
+      
+      // Step 3: Unblind signatures to get proofs
+      const proofs = await unblindSignatures(
+        data.signatures.map(s => ({
+          id: s.id,
+          amount: s.amount,
+          C_: s.C_,
+        })),
+        outputData
+      );
+      
+      set({ mintedProofs: proofs });
+      
+      // Step 4: Add proofs to wallet
+      useWalletStore.getState().addProofs(proofs);
+      
+      debugLog('wallet', 'Mint complete!', { 
+        proofCount: proofs.length,
+        totalAmount: proofs.reduce((s, p) => s + p.amount, 0)
+      });
+      
+      set({ isMinting: false });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      debugLog('error', 'Minting error', { error: message });
+      set({ 
+        isMinting: false, 
+        error: message 
+      });
+    }
+  },
+  
+  reset: () => {
+    debugLog('event', 'Purchase state reset');
+    set({
+      quoteId: null,
+      bolt11: null,
+      quoteAmount: 0,
+      quoteExpiry: null,
+      quotePaid: false,
+      blindedOutputs: null,
+      outputData: null,
+      mintedProofs: null,
+      isCreatingQuote: false,
+      isCheckingStatus: false,
+      isMinting: false,
+      error: null,
+    });
+  },
+}));

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -1,0 +1,77 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { Proof } from '@cashu/cashu-ts';
+import { debugLog } from './debug';
+
+interface WalletState {
+  proofs: Proof[];
+  pendingProofs: Proof[];
+  
+  // Computed
+  getBalance: () => number;
+  
+  // Actions
+  addProofs: (proofs: Proof[]) => void;
+  removeProofs: (proofs: Proof[]) => void;
+  markPending: (proofs: Proof[]) => void;
+  clearPending: () => void;
+  reset: () => void;
+}
+
+export const useWalletStore = create<WalletState>()(
+  persist(
+    (set, get) => ({
+      proofs: [],
+      pendingProofs: [],
+      
+      getBalance: () => {
+        const { proofs } = get();
+        return proofs.reduce((sum, p) => sum + p.amount, 0);
+      },
+      
+      addProofs: (newProofs) => {
+        debugLog('wallet', 'Adding proofs', { 
+          count: newProofs.length, 
+          amounts: newProofs.map(p => p.amount),
+          total: newProofs.reduce((s, p) => s + p.amount, 0)
+        });
+        set((state) => ({
+          proofs: [...state.proofs, ...newProofs],
+        }));
+      },
+      
+      removeProofs: (proofsToRemove) => {
+        const secrets = new Set(proofsToRemove.map(p => p.secret));
+        debugLog('wallet', 'Removing proofs', { 
+          count: proofsToRemove.length,
+          amounts: proofsToRemove.map(p => p.amount)
+        });
+        set((state) => ({
+          proofs: state.proofs.filter(p => !secrets.has(p.secret)),
+        }));
+      },
+      
+      markPending: (proofs) => {
+        debugLog('wallet', 'Marking proofs as pending', { 
+          count: proofs.length,
+          amounts: proofs.map(p => p.amount)
+        });
+        set({ pendingProofs: proofs });
+      },
+      
+      clearPending: () => {
+        debugLog('wallet', 'Clearing pending proofs');
+        set({ pendingProofs: [] });
+      },
+      
+      reset: () => {
+        debugLog('wallet', 'Wallet reset');
+        set({ proofs: [], pendingProofs: [] });
+      },
+    }),
+    {
+      name: 'wavlake-wallet',
+      partialize: (state) => ({ proofs: state.proofs }),
+    }
+  )
+);


### PR DESCRIPTION
Quote → Check → Mint flow with debug logging

## What this adds

### Purchase Flow
1. **Create Quote** - POST to `/api/v1/credits/quote` with desired amount
2. **Pay Invoice** - Lightning invoice displayed with copy button  
3. **Check Status** - Poll quote status until paid
4. **Mint Tokens** - Generate blinded outputs, POST to mint, unblind signatures

### New Files
- `src/stores/wallet.ts` - Zustand store for wallet proofs with localStorage persistence
- `src/stores/purchase.ts` - Zustand store for purchase flow state
- `src/lib/blinding.ts` - Cashu blinding utilities using cashu-ts
- `src/components/PurchasePanel.tsx` - UI for the purchase flow

### Debug Logging
Every action logs to the debug panel:
- API requests/responses
- Wallet operations (add proofs, balance changes)
- Minting steps (create outputs, unblind signatures)

### Integration
- After successful mint, proofs are added to wallet store
- Wallet balance updates automatically
- All state visible in debug panels