### PR TITLE
React: Add useContentPrice and useTrackPayment hooks

### DIFF
--- a/packages/paywall-react/src/hooks/useContentPrice.ts
+++ b/packages/paywall-react/src/hooks/useContentPrice.ts
@@ -1,0 +1,171 @@
+'use client';
+
+/**
+ * useContentPrice Hook
+ * 
+ * Fetch and cache content prices for display.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { usePaywallContext } from '../providers/PaywallProvider.js';
+
+export interface ContentPriceState {
+  /** Content price in credits (null if loading or error) */
+  price: number | null;
+  /** Whether the content is free (price === 0) */
+  isFree: boolean;
+  /** Loading state */
+  isLoading: boolean;
+  /** Error if price check failed */
+  error: Error | null;
+  /** Refetch the price */
+  refetch: () => void;
+}
+
+/**
+ * Fetch the price of content.
+ * 
+ * Caches prices to avoid redundant API calls.
+ * 
+ * @example
+ * ```tsx
+ * function TrackCard({ dtag }: { dtag: string }) {
+ *   const { price, isFree, isLoading } = useContentPrice(dtag);
+ *   
+ *   if (isLoading) return <span>...</span>;
+ *   
+ *   return (
+ *     <span>{isFree ? 'Free' : `${price} credits`}</span>
+ *   );
+ * }
+ * ```
+ */
+export function useContentPrice(dtag: string | undefined): ContentPriceState {
+  const { getContentPrice } = usePaywallContext();
+  const [price, setPrice] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  
+  // Simple in-memory cache (per-client instance)
+  const cacheRef = useRef<Map<string, number>>(new Map());
+
+  const fetchPrice = useCallback(async () => {
+    if (!dtag) {
+      setPrice(null);
+      return;
+    }
+
+    // Check cache first
+    const cached = cacheRef.current.get(dtag);
+    if (cached !== undefined) {
+      setPrice(cached);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const contentPrice = await getContentPrice(dtag);
+      cacheRef.current.set(dtag, contentPrice);
+      setPrice(contentPrice);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Failed to fetch price'));
+      setPrice(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [dtag, getContentPrice]);
+
+  const refetch = useCallback(() => {
+    if (dtag) {
+      cacheRef.current.delete(dtag);
+      fetchPrice();
+    }
+  }, [dtag, fetchPrice]);
+
+  useEffect(() => {
+    fetchPrice();
+  }, [fetchPrice]);
+
+  return {
+    price,
+    isFree: price === 0,
+    isLoading,
+    error,
+    refetch,
+  };
+}
+
+/**
+ * Batch fetch prices for multiple content items
+ * 
+ * @example
+ * ```tsx
+ * function TrackList({ dtags }: { dtags: string[] }) {
+ *   const { prices, isLoading } = useContentPrices(dtags);
+ *   
+ *   return (
+ *     <ul>
+ *       {dtags.map(dtag => (
+ *         <li key={dtag}>
+ *           {dtag}: {prices[dtag] ?? '...'} credits
+ *         </li>
+ *       ))}
+ *     </ul>
+ *   );
+ * }
+ * ```
+ */
+export function useContentPrices(dtags: string[]): {
+  prices: Record<string, number | null>;
+  isLoading: boolean;
+  errors: Record<string, Error>;
+} {
+  const { getContentPrice } = usePaywallContext();
+  const [prices, setPrices] = useState<Record<string, number | null>>({});
+  const [errors, setErrors] = useState<Record<string, Error>>({});
+  const [isLoading, setIsLoading] = useState(false);
+  
+  const cacheRef = useRef<Map<string, number>>(new Map());
+  const dtagsKey = dtags.join(',');
+
+  useEffect(() => {
+    if (dtags.length === 0) return;
+
+    const fetchAll = async () => {
+      setIsLoading(true);
+      
+      const newPrices: Record<string, number | null> = {};
+      const newErrors: Record<string, Error> = {};
+
+      await Promise.all(
+        dtags.map(async (dtag) => {
+          // Check cache
+          const cached = cacheRef.current.get(dtag);
+          if (cached !== undefined) {
+            newPrices[dtag] = cached;
+            return;
+          }
+
+          try {
+            const price = await getContentPrice(dtag);
+            cacheRef.current.set(dtag, price);
+            newPrices[dtag] = price;
+          } catch (err) {
+            newErrors[dtag] = err instanceof Error ? err : new Error('Failed');
+            newPrices[dtag] = null;
+          }
+        })
+      );
+
+      setPrices(newPrices);
+      setErrors(newErrors);
+      setIsLoading(false);
+    };
+
+    fetchAll();
+  }, [dtagsKey, getContentPrice]);
+
+  return { prices, isLoading, errors };
+}

--- a/packages/paywall-react/src/hooks/useTrackPayment.ts
+++ b/packages/paywall-react/src/hooks/useTrackPayment.ts
@@ -1,0 +1,191 @@
+'use client';
+
+/**
+ * useTrackPayment Hook
+ * 
+ * Complete payment flow for track access.
+ * Combines wallet token creation with paywall content request.
+ */
+
+import { useState, useCallback } from 'react';
+import { usePaywallContext } from '../providers/PaywallProvider.js';
+import { useWalletContext } from '../providers/WalletProvider.js';
+import { PaywallError } from '@wavlake/paywall-client';
+import type { ContentResult } from '@wavlake/paywall-client';
+
+export type PaymentStatus = 
+  | 'idle'
+  | 'checking-price'
+  | 'creating-token'
+  | 'requesting-content'
+  | 'success'
+  | 'error';
+
+export interface TrackPaymentState {
+  /** Current payment status */
+  status: PaymentStatus;
+  /** Content result if successful */
+  result: ContentResult | null;
+  /** Error if failed */
+  error: Error | null;
+  /** User-friendly error message */
+  errorMessage: string | null;
+  /** Whether payment is in progress */
+  isProcessing: boolean;
+  /** Pay for and access a track */
+  pay: (dtag: string, amount?: number) => Promise<ContentResult | null>;
+  /** Replay existing grant (no payment) */
+  replay: (dtag: string, grantId: string) => Promise<ContentResult | null>;
+  /** Reset state */
+  reset: () => void;
+}
+
+/**
+ * Complete payment flow for track access.
+ * 
+ * Handles:
+ * - Price checking
+ * - Token creation
+ * - Content request
+ * - Change handling
+ * - Error recovery
+ * 
+ * @example
+ * ```tsx
+ * function PlayButton({ dtag, price }: { dtag: string; price: number }) {
+ *   const { pay, status, errorMessage, result } = useTrackPayment();
+ *   const { balance } = useWallet();
+ *   
+ *   const handleClick = async () => {
+ *     const content = await pay(dtag, price);
+ *     if (content) {
+ *       playAudio(content.url);
+ *     }
+ *   };
+ *   
+ *   if (status === 'success' && result) {
+ *     return <span>Playing!</span>;
+ *   }
+ *   
+ *   if (status === 'error') {
+ *     return <span className="error">{errorMessage}</span>;
+ *   }
+ *   
+ *   return (
+ *     <button 
+ *       onClick={handleClick}
+ *       disabled={status !== 'idle' || balance < price}
+ *     >
+ *       {status === 'idle' ? `Pay ${price}` : 'Processing...'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
+export function useTrackPayment(): TrackPaymentState {
+  const { requestContent, replayGrant, getContentPrice } = usePaywallContext();
+  const { createToken, receiveToken } = useWalletContext();
+
+  const [status, setStatus] = useState<PaymentStatus>('idle');
+  const [result, setResult] = useState<ContentResult | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  const reset = useCallback(() => {
+    setStatus('idle');
+    setResult(null);
+    setError(null);
+  }, []);
+
+  const pay = useCallback(async (
+    dtag: string,
+    amount?: number
+  ): Promise<ContentResult | null> => {
+    try {
+      setError(null);
+      setResult(null);
+
+      // Step 1: Check price if not provided
+      let price = amount;
+      if (price === undefined) {
+        setStatus('checking-price');
+        price = await getContentPrice(dtag);
+      }
+
+      // Free content - no payment needed
+      if (price === 0) {
+        setStatus('requesting-content');
+        const content = await requestContent(dtag, '');
+        setResult(content);
+        setStatus('success');
+        return content;
+      }
+
+      // Step 2: Create token
+      setStatus('creating-token');
+      const token = await createToken(price);
+
+      // Step 3: Request content
+      setStatus('requesting-content');
+      const content = await requestContent(dtag, token);
+
+      // Step 4: Handle change if present
+      if (content.change) {
+        try {
+          await receiveToken(content.change);
+        } catch (changeErr) {
+          // Log but don't fail - change handling is best-effort
+          console.warn('Failed to receive change:', changeErr);
+        }
+      }
+
+      setResult(content);
+      setStatus('success');
+      return content;
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Payment failed'));
+      setStatus('error');
+      return null;
+    }
+  }, [getContentPrice, requestContent, createToken, receiveToken]);
+
+  const replay = useCallback(async (
+    dtag: string,
+    grantId: string
+  ): Promise<ContentResult | null> => {
+    try {
+      setError(null);
+      setResult(null);
+      setStatus('requesting-content');
+
+      const content = await replayGrant(dtag, grantId);
+      setResult(content);
+      setStatus('success');
+      return content;
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Replay failed'));
+      setStatus('error');
+      return null;
+    }
+  }, [replayGrant]);
+
+  // Derive user-friendly error message
+  let errorMessage: string | null = null;
+  if (error) {
+    if (PaywallError.isPaywallError(error)) {
+      errorMessage = error.userMessage;
+    } else {
+      errorMessage = error.message;
+    }
+  }
+
+  return {
+    status,
+    result,
+    error,
+    errorMessage,
+    isProcessing: !['idle', 'success', 'error'].includes(status),
+    pay,
+    replay,
+    reset,
+  };
+}

--- a/packages/paywall-react/src/index.ts
+++ b/packages/paywall-react/src/index.ts
@@ -87,6 +87,18 @@ export {
   type UseTrackPlayerOptions,
 } from './hooks/useTrackPlayer.js';
 
+export {
+  useContentPrice,
+  useContentPrices,
+  type ContentPriceState,
+} from './hooks/useContentPrice.js';
+
+export {
+  useTrackPayment,
+  type TrackPaymentState,
+  type PaymentStatus,
+} from './hooks/useTrackPayment.js';
+
 // Re-export types from dependencies for convenience
 export type {
   Proof,

--- a/packages/paywall-react/src/providers/PaywallProvider.tsx
+++ b/packages/paywall-react/src/providers/PaywallProvider.tsx
@@ -31,6 +31,10 @@ export interface PaywallContextValue {
   requestAudio: (dtag: string, token: string) => Promise<AudioResult>;
   /** Request content with grant */
   requestContent: (dtag: string, token: string) => Promise<ContentResult>;
+  /** Replay existing grant */
+  replayGrant: (dtag: string, grantId: string) => Promise<ContentResult>;
+  /** Get content price */
+  getContentPrice: (dtag: string) => Promise<number>;
   /** Generate URL with embedded token */
   getAudioUrl: (dtag: string, token: string, paymentId?: string) => string;
   /** Fetch change from overpayment */
@@ -150,6 +154,29 @@ export function PaywallProvider({
     }
   }, []);
 
+  const replayGrant = useCallback(async (dtag: string, grantId: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      return await clientRef.current.replayGrant(dtag, grantId);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const getContentPrice = useCallback(async (dtag: string) => {
+    try {
+      return await clientRef.current.getContentPrice(dtag);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      throw error;
+    }
+  }, []);
+
   const clearError = useCallback(() => {
     setError(null);
   }, []);
@@ -157,6 +184,8 @@ export function PaywallProvider({
   const value: PaywallContextValue = {
     requestAudio,
     requestContent,
+    replayGrant,
+    getContentPrice,
     getAudioUrl,
     fetchChange,
     isLoading,


### PR DESCRIPTION
## Summary

New React hooks for easier paywall integration.

### useContentPrice(dtag)

Fetch and cache content prices for display.

```tsx
function TrackCard({ dtag }: { dtag: string }) {
  const { price, isFree, isLoading } = useContentPrice(dtag);
  
  return <span>{isFree ? 'Free' : `${price} credits`}</span>;
}
```

### useContentPrices(dtags)

Batch fetch prices for multiple items with parallel loading.

```tsx
function TrackList({ dtags }: { dtags: string[] }) {
  const { prices, isLoading } = useContentPrices(dtags);
  // prices = { 'dtag1': 5, 'dtag2': 0, ... }
}
```

### useTrackPayment()

Complete payment flow in one hook.

```tsx
function PlayButton({ dtag, price }: Props) {
  const { pay, status, errorMessage } = useTrackPayment();
  
  const handleClick = async () => {
    const content = await pay(dtag, price);
    if (content) playAudio(content.url);
  };
  
  return (
    <button onClick={handleClick} disabled={status !== 'idle'}>
      {status === 'idle' ? 'Pay' : status}
    </button>
  );
}
```

Handles:
- Price checking (if amount not provided)
- Token creation from wallet
- Content request
- Change handling (auto-receives)
- Grant replay

### Provider Updates

Added to PaywallContextValue:
- `replayGrant(dtag, grantId)`
- `getContentPrice(dtag)`