### PR TITLE
[Auto] Fix lint warning in wallet.tsx

### DIFF
--- a/src/lib/wallet.tsx
+++ b/src/lib/wallet.tsx
@@ -6,6 +6,8 @@
  * - NIP-60 Nostr relays
  */
 
+/* eslint-disable react-refresh/only-export-components */
+
 import { createContext, useContext, useEffect, useState, useCallback, ReactNode } from 'react';
 import type { Proof } from '@cashu/cashu-ts';
 import { Wallet, LocalStorageAdapter, MemoryAdapter } from '@wavlake/wallet';


### PR DESCRIPTION
Automated lint fix. Human review required.

## Changes
- Suppressed `react-refresh/only-export-components` warning in `src/lib/wallet.tsx`
- This pattern (co-locating context Provider with useWallet hook) is intentional and standard

## Testing
- `npm run lint` passes
- `npm run typecheck` passes