### PR TITLE
fix: correct API paths in paywall-client tests and configure workspace

### DIFF
--- a/packages/nostr-wallet/vitest.config.ts
+++ b/packages/nostr-wallet/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.d.ts'],
+    },
+  },
+});

--- a/packages/paywall-client/test/client.test.ts
+++ b/packages/paywall-client/test/client.test.ts
@@ -44,7 +44,7 @@ describe('PaywallClient', () => {
   describe('requestContent', () => {
     it('should return content result on success', async () => {
       server.use(
-        http.get(`${API_URL}/v1/content/test-track`, () => {
+        http.get(`${API_URL}/api/v1/content/test-track`, () => {
           return HttpResponse.json({
             success: true,
             data: {
@@ -69,7 +69,7 @@ describe('PaywallClient', () => {
 
     it('should throw PaywallError on 402', async () => {
       server.use(
-        http.get(`${API_URL}/v1/content/paid-track`, () => {
+        http.get(`${API_URL}/api/v1/content/paid-track`, () => {
           return HttpResponse.json(
             {
               success: false,
@@ -104,7 +104,7 @@ describe('PaywallClient', () => {
       let capturedHeaders: Headers | null = null;
 
       server.use(
-        http.get(`${API_URL}/v1/content/test-track`, ({ request }) => {
+        http.get(`${API_URL}/api/v1/content/test-track`, ({ request }) => {
           capturedHeaders = request.headers;
           return HttpResponse.json({
             success: true,
@@ -130,7 +130,7 @@ describe('PaywallClient', () => {
   describe('getContentPrice', () => {
     it('should return 0 for free tracks', async () => {
       server.use(
-        http.get(`${API_URL}/v1/content/free-track`, () => {
+        http.get(`${API_URL}/api/v1/content/free-track`, () => {
           return HttpResponse.json({
             success: true,
             data: {
@@ -148,7 +148,7 @@ describe('PaywallClient', () => {
 
     it('should return price for paywalled tracks', async () => {
       server.use(
-        http.get(`${API_URL}/v1/content/paid-track`, () => {
+        http.get(`${API_URL}/api/v1/content/paid-track`, () => {
           return HttpResponse.json(
             {
               success: false,
@@ -177,7 +177,7 @@ describe('PaywallClient', () => {
       let capturedHeaders: Headers | null = null;
 
       server.use(
-        http.get(`${API_URL}/v1/content/test-track`, ({ request }) => {
+        http.get(`${API_URL}/api/v1/content/test-track`, ({ request }) => {
           capturedHeaders = request.headers;
           return HttpResponse.json({
             success: true,
@@ -204,7 +204,7 @@ describe('PaywallClient', () => {
   describe('fetchChange', () => {
     it('should return change token', async () => {
       server.use(
-        http.get(`${API_URL}/v1/change/payment-123`, () => {
+        http.get(`${API_URL}/api/v1/change/payment-123`, () => {
           return HttpResponse.json({
             success: true,
             data: {
@@ -226,7 +226,7 @@ describe('PaywallClient', () => {
 
     it('should return null change if already claimed', async () => {
       server.use(
-        http.get(`${API_URL}/v1/change/payment-456`, () => {
+        http.get(`${API_URL}/api/v1/change/payment-456`, () => {
           return HttpResponse.json({
             success: true,
             data: {
@@ -249,7 +249,7 @@ describe('PaywallClient', () => {
       const client = new PaywallClient({ apiUrl: API_URL });
       const url = client.getAudioUrl('track-123', 'cashuBtoken');
 
-      expect(url).toBe(`${API_URL}/v1/audio/track-123?token=cashuBtoken`);
+      expect(url).toBe(`${API_URL}/api/v1/audio/track-123?token=cashuBtoken`);
     });
 
     it('should include paymentId if provided', () => {

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,10 @@
+import { defineWorkspace } from 'vitest/config';
+
+export default defineWorkspace([
+  // Non-React packages - use node environment
+  'packages/wallet/vitest.config.ts',
+  'packages/paywall-client/vitest.config.ts',
+  'packages/nostr-wallet/vitest.config.ts',
+  // React package - uses jsdom environment
+  'packages/paywall-react/vitest.config.ts',
+]);


### PR DESCRIPTION
## Summary

This PR fixes the failing paywall-client test suite and improves the monorepo test configuration.

## Changes

### 1. Fixed API Path Mismatches in paywall-client Tests
The MSW mock handlers were using incorrect paths:
- `/v1/content/...` → `/api/v1/content/...`
- `/v1/change/...` → `/api/v1/change/...`
- `/v1/audio/...` → `/api/v1/audio/...`

This caused 9 test failures because the mocks didn't match what the actual client requests.

### 2. Added vitest.workspace.ts
Created a workspace configuration file at the root to properly configure vitest for the monorepo. This ensures each package uses its own vitest config (e.g., paywall-react uses jsdom environment for React testing).

### 3. Added vitest.config.ts for nostr-wallet
The nostr-wallet package was missing a vitest config file, which was needed for the workspace configuration to work properly.

## Testing
All 105 tests now pass (103 passing, 2 skipped):
```
Test Files  8 passed (8)
     Tests  103 passed | 2 skipped (105)
```

## Before
- 9 test failures due to API path mismatches and missing jsdom environment

## After  
- All tests pass ✅