### PR TITLE
fix(e2e): remove references to removed server-side change headers

### DIFF
--- a/tests/e2e/content.test.ts
+++ b/tests/e2e/content.test.ts
@@ -170,16 +170,14 @@ describe('Phase 2: AudioHandler (/v1/audio)', () => {
       console.log('✅ Paid audio stream started');
     });
 
-    it('should return change headers when overpaying', async () => {
+    it('should accept overpayment as artist tip', async () => {
+      // Note: Server-side change was removed in Phase 5 of Sat-to-USD PRD.
+      // Overpayment now becomes artist tip instead of being returned as change.
       if (!testToken) return;
 
       const result = await requestAudio(testTracks.paid.dtag, testToken);
-      
-      if (result.ok && result.changeToken) {
-        expect(result.changeToken.startsWith('cashuB')).toBe(true);
-        expect(result.changeAmount).toBeGreaterThan(0);
-        console.log('✅ Change in headers:', result.changeAmount, 'credits');
-      }
+      expect(result.ok).toBe(true);
+      console.log('✅ Overpayment accepted (becomes artist tip)');
     });
   });
 });

--- a/tests/e2e/helpers/api.ts
+++ b/tests/e2e/helpers/api.ts
@@ -95,8 +95,7 @@ export async function requestAudio(
   status: number;
   contentType?: string;
   contentLength?: number;
-  changeToken?: string;
-  changeAmount?: number;
+  // Note: changeToken/changeAmount removed - server-side change was removed in Phase 5
   error?: {
     code: string;
     message: string;
@@ -122,8 +121,8 @@ export async function requestAudio(
       status: response.status,
       contentType: response.headers.get('content-type') || undefined,
       contentLength: parseInt(response.headers.get('content-length') || '0'),
-      changeToken: response.headers.get('X-Cashu-Change-Token') || undefined,
-      changeAmount: parseInt(response.headers.get('X-Cashu-Change-Amount') || '0') || undefined,
+      // Note: Server-side change was removed in Phase 5 of Sat-to-USD PRD.
+      // Overpayment now becomes artist tip. Clients should prepare exact denominations.
     };
   } else {
     const json = await response.json();


### PR DESCRIPTION
## Summary

Server-side change was removed in Phase 5 of Sat-to-USD PRD (monorepo PR #702).
Overpayment now becomes artist tip. Clients should prepare exact denominations.

## Changes

- Remove `changeToken`/`changeAmount` from `requestAudio` return type in test helpers
- Update E2E tests to expect overpayment as artist tip, not change
- Add explanatory comments

## Related

- wavlake/monorepo#702 - feat(phase-5): remove server-side change mechanism for all payments