### PR TITLE
fix: resolve cross-package test failures without build step

### DIFF
--- a/packages/nostr-wallet/vitest.config.ts
+++ b/packages/nostr-wallet/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@wavlake/wallet': path.resolve(__dirname, '../wallet/src/index.ts'),
+    },
+  },
   test: {
     globals: true,
     environment: 'node',

--- a/packages/paywall-react/test/hooks/usePaywall.test.tsx
+++ b/packages/paywall-react/test/hooks/usePaywall.test.tsx
@@ -77,7 +77,7 @@ describe('usePaywall', () => {
         audioResult = await result.current.requestAudio('track-123', 'cashuBtoken');
       });
 
-      expect(mockClient.requestAudio).toHaveBeenCalledWith('track-123', 'cashuBtoken');
+      expect(mockClient.requestAudio).toHaveBeenCalledWith('track-123', 'cashuBtoken', undefined);
       expect(audioResult.audio).toBeInstanceOf(Blob);
     });
 

--- a/packages/paywall-react/test/hooks/useTrackPlayer.test.tsx
+++ b/packages/paywall-react/test/hooks/useTrackPlayer.test.tsx
@@ -169,7 +169,7 @@ describe('useTrackPlayer', () => {
         await result.current.play('track-123', 5);
       });
 
-      expect(mockClient.requestAudio).toHaveBeenCalledWith('track-123', 'cashuBtoken');
+      expect(mockClient.requestAudio).toHaveBeenCalledWith('track-123', 'cashuBtoken', undefined);
       expect(URL.createObjectURL).toHaveBeenCalled();
       expect(result.current.audioUrl).toBe(mockObjectURL);
       expect(result.current.grantId).toBe(null); // No grant with audio endpoint

--- a/packages/paywall-react/vitest.config.ts
+++ b/packages/paywall-react/vitest.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@wavlake/wallet': path.resolve(__dirname, '../wallet/src/index.ts'),
+      '@wavlake/paywall-client': path.resolve(__dirname, '../paywall-client/src/index.ts'),
+    },
+  },
   test: {
     globals: true,
     environment: 'jsdom',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,15 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@wavlake/wallet': path.resolve(__dirname, 'packages/wallet/src/index.ts'),
+      '@wavlake/paywall-client': path.resolve(__dirname, 'packages/paywall-client/src/index.ts'),
+      '@wavlake/nostr-wallet': path.resolve(__dirname, 'packages/nostr-wallet/src/index.ts'),
+      '@wavlake/paywall-react': path.resolve(__dirname, 'packages/paywall-react/src/index.ts'),
+    },
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Problem

7 of 22 test suites were failing when running `npx vitest run` from root because workspace packages (`@wavlake/wallet`, `@wavlake/paywall-client`, etc.) have their `exports` field pointing to `./dist/index.js`, which doesn't exist without a build step. This meant:

- `nostr-wallet` tests couldn't import `@wavlake/wallet`
- All 6 `paywall-react` hook tests couldn't import `@wavlake/wallet` or `@wavlake/paywall-client`
- Any new contributor cloning the repo and running `npm test` would see 7 broken suites

## Fix

Added `resolve.alias` entries to the vitest configs that map workspace packages to their `src/index.ts` files directly — standard monorepo pattern for dev-time resolution:

- **Root `vitest.config.ts`**: Aliases for all 4 workspace packages
- **`packages/nostr-wallet/vitest.config.ts`**: Alias for `@wavlake/wallet`
- **`packages/paywall-react/vitest.config.ts`**: Aliases for `@wavlake/wallet` + `@wavlake/paywall-client`

Also fixed 2 test assertions in `paywall-react` that were checking `toHaveBeenCalledWith(a, b)` but the actual call passes `undefined` as a third arg (the optional `options` parameter that gets forwarded through the provider wrapper).

## Results

| | Before | After |
|---|---|---|
| Test suites | 15 passed, **7 failed** | **22 passed**, 0 failed |
| Tests | 288 passed | **386 passed**, 2 skipped |

All three test runners pass:
- `npx vitest run` (root config)
- `npx vitest run --workspace vitest.workspace.ts`
- `npm test` (per-package scripts)