### PR TITLE
fix: complete Phase 5 change removal across SDK packages

### DIFF
--- a/packages/paywall-client/src/client.ts
+++ b/packages/paywall-client/src/client.ts
@@ -80,8 +80,6 @@ export class PaywallClient {
         dtag, 
         contentType: result.contentType, 
         size: result.audio.size,
-        hasChange: !!result.change,
-        changeAmount: result.changeAmount,
       });
       return result;
     } catch (error) {
@@ -137,8 +135,6 @@ export class PaywallClient {
         grantId: result.grant.id,
         expiresAt: result.grant.expiresAt,
         streamType: result.grant.streamType,
-        hasChange: !!result.change,
-        changeAmount: result.changeAmount,
       });
       return result;
     } catch (error) {

--- a/packages/paywall-react/src/hooks/useTrackPayment.ts
+++ b/packages/paywall-react/src/hooks/useTrackPayment.ts
@@ -84,7 +84,7 @@ export interface TrackPaymentState {
  */
 export function useTrackPayment(): TrackPaymentState {
   const { requestContent, replayGrant, getContentPrice } = usePaywallContext();
-  const { createToken, receiveToken } = useWalletContext();
+  const { createToken } = useWalletContext();
 
   const [status, setStatus] = useState<PaymentStatus>('idle');
   const [result, setResult] = useState<ContentResult | null>(null);
@@ -128,16 +128,6 @@ export function useTrackPayment(): TrackPaymentState {
       setStatus('requesting-content');
       const content = await requestContent(dtag, token);
 
-      // Step 4: Handle change if present
-      if (content.change) {
-        try {
-          await receiveToken(content.change);
-        } catch (changeErr) {
-          // Log but don't fail - change handling is best-effort
-          console.warn('Failed to receive change:', changeErr);
-        }
-      }
-
       setResult(content);
       setStatus('success');
       return content;
@@ -146,7 +136,7 @@ export function useTrackPayment(): TrackPaymentState {
       setStatus('error');
       return null;
     }
-  }, [getContentPrice, requestContent, createToken, receiveToken]);
+  }, [getContentPrice, requestContent, createToken]);
 
   const replay = useCallback(async (
     dtag: string,

--- a/packages/paywall-react/src/hooks/useTrackPlayer.ts
+++ b/packages/paywall-react/src/hooks/useTrackPlayer.ts
@@ -36,8 +36,6 @@ export interface UseTrackPlayerResult {
 export interface UseTrackPlayerOptions {
   /** Use /v1/content endpoint (default: true for grant support) */
   useContentEndpoint?: boolean;
-  /** Auto-receive change tokens */
-  autoReceiveChange?: boolean;
 }
 
 // ============================================================================
@@ -50,7 +48,6 @@ export interface UseTrackPlayerOptions {
  * Handles:
  * - Token creation from wallet
  * - Content/audio request
- * - Change processing
  * - Error handling
  * 
  * @example
@@ -82,7 +79,6 @@ export interface UseTrackPlayerOptions {
 export function useTrackPlayer(options: UseTrackPlayerOptions = {}): UseTrackPlayerResult {
   const {
     useContentEndpoint = true,
-    autoReceiveChange = true,
   } = options;
 
   const wallet = useWalletContext();
@@ -124,30 +120,12 @@ export function useTrackPlayer(options: UseTrackPlayerOptions = {}): UseTrackPla
         // Use content endpoint (supports grant replay)
         const result = await paywall.requestContent(dtag, token);
 
-        // Handle change
-        if (autoReceiveChange && result.change) {
-          try {
-            await wallet.receiveToken(result.change);
-          } catch (err) {
-            console.warn('Failed to receive change:', err);
-          }
-        }
-
         // Store grant for potential replay
         setGrantId(result.grant.id);
         setAudioUrl(result.url);
       } else {
         // Use audio endpoint (direct binary)
         const result = await paywall.requestAudio(dtag, token);
-
-        // Handle change
-        if (autoReceiveChange && result.change) {
-          try {
-            await wallet.receiveToken(result.change);
-          } catch (err) {
-            console.warn('Failed to receive change:', err);
-          }
-        }
 
         // Create blob URL
         cleanupBlobUrl();
@@ -165,7 +143,7 @@ export function useTrackPlayer(options: UseTrackPlayerOptions = {}): UseTrackPla
     } finally {
       setIsLoading(false);
     }
-  }, [wallet, paywall, useContentEndpoint, autoReceiveChange, cleanupBlobUrl]);
+  }, [wallet, paywall, useContentEndpoint, cleanupBlobUrl]);
 
   // Stop playback
   const stop = useCallback(() => {

--- a/packages/paywall-react/test/hooks/usePaywall.test.tsx
+++ b/packages/paywall-react/test/hooks/usePaywall.test.tsx
@@ -11,17 +11,14 @@ import { PaywallProvider, usePaywall } from '../../src/index.js';
 const createMockClient = () => ({
   requestAudio: vi.fn().mockResolvedValue({
     audio: new Blob(['audio-data'], { type: 'audio/mpeg' }),
-    change: null,
   }),
   requestContent: vi.fn().mockResolvedValue({
     url: 'https://cdn.wavlake.com/signed-url',
     grant: { id: 'grant-123', expiresAt: Date.now() + 600000 },
-    change: null,
   }),
   replayGrant: vi.fn().mockResolvedValue({
     url: 'https://cdn.wavlake.com/replay-url',
     grant: { id: 'grant-123', expiresAt: Date.now() + 600000 },
-    change: null,
   }),
   getContentPrice: vi.fn().mockResolvedValue(5),
   getAudioUrl: vi.fn().mockReturnValue('https://api.wavlake.com/audio/track-123?token=cashuB...'),
@@ -77,7 +74,7 @@ describe('usePaywall', () => {
         audioResult = await result.current.requestAudio('track-123', 'cashuBtoken');
       });
 
-      expect(mockClient.requestAudio).toHaveBeenCalledWith('track-123', 'cashuBtoken');
+      expect(mockClient.requestAudio).toHaveBeenCalledWith('track-123', 'cashuBtoken', undefined);
       expect(audioResult.audio).toBeInstanceOf(Blob);
     });
 
@@ -100,7 +97,7 @@ describe('usePaywall', () => {
       });
 
       await act(async () => {
-        resolvePromise!({ audio: new Blob(), change: null });
+        resolvePromise!({ audio: new Blob() });
       });
 
       expect(result.current.isLoading).toBe(false);
@@ -137,13 +134,7 @@ describe('usePaywall', () => {
       expect(contentResult.grant.id).toBe('grant-123');
     });
 
-    it('should handle content with change', async () => {
-      mockClient.requestContent.mockResolvedValue({
-        url: 'https://cdn.wavlake.com/signed-url',
-        grant: { id: 'grant-123', expiresAt: Date.now() + 600000 },
-        change: 'cashuBchangeToken',
-      });
-
+    it('should return content result with grant (no change - Phase 5)', async () => {
       const { result } = renderHook(() => usePaywall(), { wrapper });
 
       let contentResult: any;
@@ -151,7 +142,10 @@ describe('usePaywall', () => {
         contentResult = await result.current.requestContent('track-123', 'cashuBtoken');
       });
 
-      expect(contentResult.change).toBe('cashuBchangeToken');
+      // Phase 5: ContentResult only has url + grant, no change
+      expect(contentResult.url).toBe('https://cdn.wavlake.com/signed-url');
+      expect(contentResult.grant.id).toBe('grant-123');
+      expect(contentResult.change).toBeUndefined();
     });
   });
 

--- a/packages/paywall-react/test/hooks/useTrackPayment.test.tsx
+++ b/packages/paywall-react/test/hooks/useTrackPayment.test.tsx
@@ -33,12 +33,10 @@ const createMockClient = () => ({
   requestContent: vi.fn().mockResolvedValue({
     url: 'https://cdn.wavlake.com/signed-url',
     grant: { id: 'grant-123', expiresAt: Date.now() + 600000 },
-    change: null,
   }),
   replayGrant: vi.fn().mockResolvedValue({
     url: 'https://cdn.wavlake.com/replay-url',
     grant: { id: 'grant-123', expiresAt: Date.now() + 600000 },
-    change: null,
   }),
   getContentPrice: vi.fn().mockResolvedValue(5),
   getAudioUrl: vi.fn(),
@@ -115,7 +113,6 @@ describe('useTrackPayment', () => {
       mockClient.requestContent.mockResolvedValue({
         url: 'https://cdn.wavlake.com/free-content',
         grant: { id: 'grant-free', expiresAt: Date.now() + 600000 },
-        change: null,
       });
 
       const { result } = renderHook(() => useTrackPayment(), { wrapper: createWrapper() });
@@ -133,11 +130,10 @@ describe('useTrackPayment', () => {
       expect(result.current.status).toBe('success');
     });
 
-    it('should process change tokens', async () => {
+    it('should not attempt change processing (Phase 5 - overpayment is artist tip)', async () => {
       mockClient.requestContent.mockResolvedValue({
         url: 'https://cdn.wavlake.com/signed-url',
         grant: { id: 'grant-123', expiresAt: Date.now() + 600000 },
-        change: 'cashuBchangeToken',
       });
 
       const { result } = renderHook(() => useTrackPayment(), { wrapper: createWrapper() });
@@ -150,34 +146,9 @@ describe('useTrackPayment', () => {
         await result.current.pay('track-123', 5);
       });
 
-      expect(mockWallet.receiveToken).toHaveBeenCalledWith('cashuBchangeToken');
-    });
-
-    it('should continue successfully even if change handling fails', async () => {
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      
-      mockClient.requestContent.mockResolvedValue({
-        url: 'https://cdn.wavlake.com/signed-url',
-        grant: { id: 'grant-123', expiresAt: Date.now() + 600000 },
-        change: 'cashuBchangeToken',
-      });
-      mockWallet.receiveToken.mockRejectedValue(new Error('Change processing failed'));
-
-      const { result } = renderHook(() => useTrackPayment(), { wrapper: createWrapper() });
-
-      await waitFor(() => {
-        expect(result.current.status).toBe('idle');
-      });
-
-      await act(async () => {
-        await result.current.pay('track-123', 5);
-      });
-
-      // Payment should still succeed
+      // receiveToken should never be called - no change handling post Phase 5
+      expect(mockWallet.receiveToken).not.toHaveBeenCalled();
       expect(result.current.status).toBe('success');
-      expect(result.current.result?.url).toBe('https://cdn.wavlake.com/signed-url');
-      
-      consoleSpy.mockRestore();
     });
 
     it('should transition through status states', async () => {
@@ -236,7 +207,6 @@ describe('useTrackPayment', () => {
         resolveContent!({
           url: 'https://cdn.wavlake.com/signed-url',
           grant: { id: 'grant-123', expiresAt: Date.now() + 600000 },
-          change: null,
         });
       });
 
@@ -418,7 +388,6 @@ describe('useTrackPayment', () => {
         resolveContent!({
           url: 'https://cdn.wavlake.com/signed-url',
           grant: { id: 'grant-123', expiresAt: Date.now() + 600000 },
-          change: null,
         });
       });
 

--- a/packages/paywall-react/test/hooks/useTrackPlayer.test.tsx
+++ b/packages/paywall-react/test/hooks/useTrackPlayer.test.tsx
@@ -39,12 +39,10 @@ const createMockWallet = (balance = 100) => ({
 const createMockClient = () => ({
   requestAudio: vi.fn().mockResolvedValue({
     audio: new Blob(['audio-data'], { type: 'audio/mpeg' }),
-    change: null,
   }),
   requestContent: vi.fn().mockResolvedValue({
     url: 'https://cdn.wavlake.com/signed-url',
     grant: { id: 'grant-123', expiresAt: Date.now() + 600000 },
-    change: null,
   }),
   replayGrant: vi.fn(),
   getContentPrice: vi.fn().mockResolvedValue(5),
@@ -106,13 +104,7 @@ describe('useTrackPlayer', () => {
       expect(result.current.isPlaying).toBe(true);
     });
 
-    it('should handle change tokens', async () => {
-      mockClient.requestContent.mockResolvedValue({
-        url: 'https://cdn.wavlake.com/signed-url',
-        grant: { id: 'grant-123', expiresAt: Date.now() + 600000 },
-        change: 'cashuBchangeToken',
-      });
-
+    it('should not attempt change processing (Phase 5 - overpayment is artist tip)', async () => {
       const { result } = renderHook(() => useTrackPlayer(), { wrapper: createWrapper() });
 
       await waitFor(() => {
@@ -123,34 +115,10 @@ describe('useTrackPlayer', () => {
         await result.current.play('track-123', 5);
       });
 
-      expect(mockWallet.receiveToken).toHaveBeenCalledWith('cashuBchangeToken');
-    });
-
-    it('should continue if change handling fails', async () => {
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      
-      mockClient.requestContent.mockResolvedValue({
-        url: 'https://cdn.wavlake.com/signed-url',
-        grant: { id: 'grant-123', expiresAt: Date.now() + 600000 },
-        change: 'cashuBchangeToken',
-      });
-      mockWallet.receiveToken.mockRejectedValue(new Error('Change failed'));
-
-      const { result } = renderHook(() => useTrackPlayer(), { wrapper: createWrapper() });
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      await act(async () => {
-        await result.current.play('track-123', 5);
-      });
-
-      // Play should still succeed
+      // receiveToken should never be called - no change handling post Phase 5
+      expect(mockWallet.receiveToken).not.toHaveBeenCalled();
       expect(result.current.isPlaying).toBe(true);
       expect(result.current.audioUrl).toBe('https://cdn.wavlake.com/signed-url');
-      
-      consoleSpy.mockRestore();
     });
   });
 
@@ -169,18 +137,13 @@ describe('useTrackPlayer', () => {
         await result.current.play('track-123', 5);
       });
 
-      expect(mockClient.requestAudio).toHaveBeenCalledWith('track-123', 'cashuBtoken');
+      expect(mockClient.requestAudio).toHaveBeenCalledWith('track-123', 'cashuBtoken', undefined);
       expect(URL.createObjectURL).toHaveBeenCalled();
       expect(result.current.audioUrl).toBe(mockObjectURL);
       expect(result.current.grantId).toBe(null); // No grant with audio endpoint
     });
 
-    it('should handle audio response change', async () => {
-      mockClient.requestAudio.mockResolvedValue({
-        audio: new Blob(['audio-data'], { type: 'audio/mpeg' }),
-        change: 'cashuBchangeToken',
-      });
-
+    it('should not attempt change processing for audio (Phase 5)', async () => {
       const { result } = renderHook(
         () => useTrackPlayer({ useContentEndpoint: false }),
         { wrapper: createWrapper() }
@@ -194,29 +157,9 @@ describe('useTrackPlayer', () => {
         await result.current.play('track-123', 5);
       });
 
-      expect(mockWallet.receiveToken).toHaveBeenCalledWith('cashuBchangeToken');
-    });
-
-    it('should not receive change when autoReceiveChange is false', async () => {
-      mockClient.requestAudio.mockResolvedValue({
-        audio: new Blob(['audio-data'], { type: 'audio/mpeg' }),
-        change: 'cashuBchangeToken',
-      });
-
-      const { result } = renderHook(
-        () => useTrackPlayer({ useContentEndpoint: false, autoReceiveChange: false }),
-        { wrapper: createWrapper() }
-      );
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      await act(async () => {
-        await result.current.play('track-123', 5);
-      });
-
+      // receiveToken should never be called - no change handling post Phase 5
       expect(mockWallet.receiveToken).not.toHaveBeenCalled();
+      expect(result.current.isPlaying).toBe(true);
     });
   });
 
@@ -269,7 +212,6 @@ describe('useTrackPlayer', () => {
         resolveContent!({
           url: 'https://cdn.wavlake.com/signed-url',
           grant: { id: 'grant-123', expiresAt: Date.now() + 600000 },
-          change: null,
         });
       });
 
@@ -471,12 +413,10 @@ describe('useTrackPlayer', () => {
         .mockResolvedValueOnce({
           url: 'https://cdn.wavlake.com/track-1',
           grant: { id: 'grant-1', expiresAt: Date.now() + 600000 },
-          change: null,
         })
         .mockResolvedValueOnce({
           url: 'https://cdn.wavlake.com/track-2',
           grant: { id: 'grant-2', expiresAt: Date.now() + 600000 },
-          change: null,
         });
 
       const { result } = renderHook(() => useTrackPlayer(), { wrapper: createWrapper() });

--- a/packages/wallet/src/errors.ts
+++ b/packages/wallet/src/errors.ts
@@ -179,7 +179,6 @@ export function generateSuggestion(code: TokenCreationErrorCode, context: {
         return 'Wallet is empty. Add credits to continue.';
       }
       const minDenom = Math.min(...availableDenominations);
-      const maxDenom = Math.max(...availableDenominations);
       // Check if all proofs are too large (single large denomination)
       if (availableDenominations.length === 1 && minDenom > requestedAmount) {
         return `Only have ${minDenom}-credit proofs. A swap will break these into smaller denominations.`;


### PR DESCRIPTION
## Summary

The Phase 5 Sat-to-USD PRD correctly removed server-side change from the API types (`ContentResult`, `AudioResult`), but the implementation code still referenced the removed `change` and `changeAmount` properties. This broke TypeScript builds across 3 packages.

## What Changed

### `@wavlake/wallet`
- Removed unused `maxDenom` variable in `generateSuggestion()` (`noUnusedLocals` error)

### `@wavlake/paywall-client`
- Removed `result.change` and `result.changeAmount` from log statements in `PaywallClient.requestAudio()` and `requestContent()`

### `@wavlake/paywall-react`
- **`useTrackPayment`**: Removed dead change handling block that called `receiveToken(content.change)` — `ContentResult` no longer has `change`
- **`useTrackPlayer`**: Removed change handling for both content and audio endpoints; removed `autoReceiveChange` option (no longer relevant)
- Updated dependency arrays to remove stale references

### Tests
- Replaced change processing tests with Phase 5-aware assertions (verify `receiveToken` is NOT called)
- Cleaned all `change: null` mock data from test fixtures
- Fixed `requestAudio` call assertions to include the `options` parameter

## Before This Fix

```
npm run build
→ paywall-client: Property 'change' does not exist on type 'AudioResult'
→ paywall-client: Property 'changeAmount' does not exist on type 'AudioResult'
→ paywall-react: Property 'change' does not exist on type 'ContentResult'
→ wallet: 'maxDenom' is declared but its value is never read
```

## After This Fix

All 5 packages build ✅  
All 385 tests pass ✅  
Net: **-134 lines** of dead code

## How to Test

```bash
# Build in dependency order
npm run build --workspace=packages/wallet
npm run build --workspace=packages/paywall-client
npm run build --workspace=packages/nostr-wallet
npm run build --workspace=packages/paywall-react
npm run build --workspace=packages/paywall-react-native

# Run tests
npm test --workspaces --if-present
```